### PR TITLE
fixed fatal error if no user found

### DIFF
--- a/src/Http/Middleware/ShopifyAuthCheck.php
+++ b/src/Http/Middleware/ShopifyAuthCheck.php
@@ -55,12 +55,12 @@ class ShopifyAuthCheck
         if (!$request->session()->has('shopifyapp') || $reSetSession) {
             $shopUrl = $request->get('shop');
             $shopifyUser = $this->getUser($shopUrl, $appName);
-            $shopifyApp = $shopifyUser->shopifyAppUsers->first();
 
             if (!$shopifyUser) {
                 return abort(403, 'No shopify user found and no active sessions');
             }
 
+            $shopifyApp = $shopifyUser->shopifyAppUsers->first();
             $request->session()->put('shopifyapp', [
                 'shop_url' => $shopUrl,
                 'access_token' => $shopifyApp->access_token,


### PR DESCRIPTION
If no shopify user, it was attempting to access a property off it causing an error to be thrown.